### PR TITLE
[test] Add PyTest to SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .venv
 venv/
 venv.bak/
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+[project.optional-dependencies]
+tests = [
+    'pytest >= 6',
+    'pytest-cov >= 4',
+    'pytest-asyncio >= 0.14',
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-rA -q -s"
+testpaths = [
+    "tests",
+]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,58 @@
+import os
+import pytest
+
+from deepgram._types import (Options, PrerecordedOptions)
+from deepgram.transcription import *
+
+
+@pytest.fixture
+def example_wav_url() -> str:
+    return os.environ.get('DEEPGRAM_PRERECORDED_URL', None)
+
+
+@pytest.fixture
+def example_wav_file() -> str:
+    return os.environ.get('DEEPGRAM_PRERECORDED_WAV', None)
+
+
+@pytest.fixture
+def options() -> Options:
+    return {
+        'api_key': os.environ.get('DEEPGRAM_API_KEY', None),
+    }
+
+
+class TestPrerecordedTranscription:
+    @pytest.fixture(autouse=True)
+    def set_instance(self, options: Options) -> PrerecordedTranscription:
+        self.instance = PrerecordedTranscription(options, None)
+
+    
+    @pytest.mark.asyncio
+    async def test_transcribe_prerecorded_url(self, example_wav_url):
+        source = PrerecordedOptions({'url': example_wav_url})
+        response = await self.instance(source)
+        assert 'results' in response
+
+
+    @pytest.mark.asyncio
+    async def test_transcribe_prerecorded_file(self, example_wav_file):
+        with open(example_wav_file, 'rb') as audio:
+            source = PrerecordedOptions(
+                {'buffer': audio, 'mimetype': 'audio/wav'}
+            )
+            response = await self.instance(source)
+            assert 'results' in response
+
+
+class TestTranscription:
+    @pytest.fixture(autouse=True)
+    def set_instance(self, options: Options) -> Transcription:
+        self.instance = Transcription(options)
+
+
+    @pytest.mark.asyncio
+    async def test_prerecorded(self, example_wav_url):
+        source = PrerecordedOptions({'url': example_wav_url})
+        response = await self.instance.prerecorded(source)
+        assert 'results' in response


### PR DESCRIPTION
### Overview

- Adds PyTest testing tool to the Python SDK.
- Adds tests for `PrerecordedTranscription` and `Transcription.prerecorded` classes/methods.
- Fixes #54.

### Example Test Run Output

```bash
$ DEEPGRAM_PRERECORDED_URL=https://static.deepgram.com/examples/interview_speech-analytics.wav \ 
DEEPGRAM_PRERECORDED_WAV=~/Downloads/interview_speech-analytics.wav \
DEEPGRAM_API_KEY=****** pytest --cov

...
============================================ PASSES ============================================

---------- coverage: platform linux, python 3.7.14-final-0 -----------
Name                          Stmts   Miss  Cover
-------------------------------------------------
deepgram/__init__.py             43     14    67%
deepgram/_constants.py            1      0   100%
deepgram/_enums.py                6      0   100%
deepgram/_types.py              223      2    99%
deepgram/_utils.py               88     40    55%
deepgram/_version.py              1      0   100%
deepgram/billing.py              10      3    70%
deepgram/invitations.py          14      5    64%
deepgram/keys.py                 15      5    67%
deepgram/members.py              10      3    70%
deepgram/projects.py             16      6    62%
deepgram/scopes.py               13      6    54%
deepgram/transcription.py       103     58    44%
deepgram/usage.py                21     11    48%
tests/__init__.py                 0      0   100%
tests/test_transcription.py      34      0   100%
-------------------------------------------------
TOTAL                           598    153    74%

=================================== short test summary info ====================================
PASSED tests/test_transcription.py::TestPrerecordedTranscription::test_transcribe_prerecorded_url
PASSED tests/test_transcription.py::TestPrerecordedTranscription::test_transcribe_prerecorded_file
PASSED tests/test_transcription.py::TestTranscription::test_prerecorded
3 passed in 40.66s
```