### PR TITLE
fix: remove testpypi we don't need it in the workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,10 +80,6 @@ jobs:
         run: poetry install
       - name: Build package
         run: poetry build
-      - name: Publish to TestPyPI
-        env:
-          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: poetry publish --repository testpypi
       - name: Publish to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Simplified the release workflow by removing the TestPyPI publishing step; releases now publish directly to PyPI.
  * Eliminated related TestPyPI environment configuration; PyPI publishing logic and error handling remain unchanged.
  * Expected impact: faster availability of releases on PyPI and a leaner pipeline.
  * No changes to application behavior or public interfaces; end-users will see no functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->