### PR TITLE
feat: mention keep alive in migration guide

### DIFF
--- a/docs/Migrating-v3-to-v5.md
+++ b/docs/Migrating-v3-to-v5.md
@@ -887,18 +887,6 @@ with client.agent.v1.connect() as agent:
     agent.send_control(AgentV1ControlMessage(type="KeepAlive"))
 ```
 
-**Key Changes:**
-
-1. **WebSocket Library Upgrade**: The SDK upgraded to `websockets>=12.0`, which introduced some internal changes to connection handling.
-
-2. **Parameter Name Changes**: 
-   - **Sync connections**: Continue to use `additional_headers` parameter
-   - **Async connections**: Now use `extra_headers` parameter (changed from `additional_headers`)
-
-3. **Keep Alive Control Messages**: The keep alive functionality itself remains unchanged - you still send `KeepAlive` control messages using the `send_control()` method.
-
-4. **Connection Management**: The underlying WebSocket connection management has been updated to use the newer websockets library API, but the public interface for keep alive remains the same.
-
 ## Breaking Changes Summary
 
 ### Major Changes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - WebSocket keep-alive is no longer automatic/config-based; send explicit control messages via the API to maintain connections.
  - Async connections now use extra_headers (renamed from additional_headers); sync connections remain unchanged.
- Documentation
  - Migration guide updated with a new WebSocket Keep Alive section, examples for control-message-based keep-alives, a checklist item, and updated breaking changes.
- Chores
  - Upgraded underlying WebSocket library, which may affect connection handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->