### PR TITLE
support multiple keyterms for v2 listen client

### DIFF
--- a/src/deepgram/listen/v2/client.py
+++ b/src/deepgram/listen/v2/client.py
@@ -43,7 +43,7 @@ class V2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -67,7 +67,8 @@ class V2Client:
 
         eot_timeout_ms : typing.Optional[str]
 
-        keyterm : typing.Optional[str]
+        keyterm : typing.Optional[typing.Union[str, typing.List[str]]]
+            Single keyterm as string or list of keyterms. Each keyterm can be up to 100 characters.
 
         mip_opt_out : typing.Optional[str]
 
@@ -100,7 +101,11 @@ class V2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, list):
+                for kt in keyterm:
+                    query_params = query_params.add("keyterm", kt)
+            else:
+                query_params = query_params.add("keyterm", keyterm)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:
@@ -154,7 +159,7 @@ class AsyncV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -178,7 +183,8 @@ class AsyncV2Client:
 
         eot_timeout_ms : typing.Optional[str]
 
-        keyterm : typing.Optional[str]
+        keyterm : typing.Optional[typing.Union[str, typing.List[str]]]
+            Single keyterm as string or list of keyterms. Each keyterm can be up to 100 characters.
 
         mip_opt_out : typing.Optional[str]
 
@@ -211,7 +217,11 @@ class AsyncV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, list):
+                for kt in keyterm:
+                    query_params = query_params.add("keyterm", kt)
+            else:
+                query_params = query_params.add("keyterm", keyterm)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:

--- a/src/deepgram/listen/v2/raw_client.py
+++ b/src/deepgram/listen/v2/raw_client.py
@@ -31,7 +31,7 @@ class RawV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -55,7 +55,8 @@ class RawV2Client:
 
         eot_timeout_ms : typing.Optional[str]
 
-        keyterm : typing.Optional[str]
+        keyterm : typing.Optional[typing.Union[str, typing.List[str]]]
+            Single keyterm as string or list of keyterms. Each keyterm can be up to 100 characters.
 
         mip_opt_out : typing.Optional[str]
 
@@ -88,7 +89,11 @@ class RawV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, list):
+                for kt in keyterm:
+                    query_params = query_params.add("keyterm", kt)
+            else:
+                query_params = query_params.add("keyterm", keyterm)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:
@@ -131,7 +136,7 @@ class AsyncRawV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -155,7 +160,8 @@ class AsyncRawV2Client:
 
         eot_timeout_ms : typing.Optional[str]
 
-        keyterm : typing.Optional[str]
+        keyterm : typing.Optional[typing.Union[str, typing.List[str]]]
+            Single keyterm as string or list of keyterms. Each keyterm can be up to 100 characters.
 
         mip_opt_out : typing.Optional[str]
 
@@ -188,7 +194,11 @@ class AsyncRawV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, list):
+                for kt in keyterm:
+                    query_params = query_params.add("keyterm", kt)
+            else:
+                query_params = query_params.add("keyterm", keyterm)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:


### PR DESCRIPTION
https://github.com/orgs/deepgram/discussions/1422#discussioncomment-14619854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support providing multiple keyterms when starting a Listen v2 streaming connection. Accepts a single keyterm or a list, enabling multiple keyterms in one request.

- Documentation
  - Updated parameter descriptions to reflect support for multiple keyterms and clarified character limit guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->