### PR TITLE
Investigate connection start listening bug

### DIFF
--- a/BUG_ANALYSIS_SUMMARY.md
+++ b/BUG_ANALYSIS_SUMMARY.md
@@ -1,0 +1,118 @@
+# Bug Analysis Summary: `start_listening()` Blocking Issue
+
+## 🐛 The Problem
+
+You're experiencing a bug where `connection.start_listening()` never returns, preventing subsequent code from executing. **This is the expected behavior**, but it's poorly documented.
+
+## 🔍 What's Happening
+
+The `start_listening()` method contains an **infinite loop** that blocks until the websocket connection closes:
+
+```python
+def start_listening(self):
+    self._emit(EventType.OPEN, None)
+    try:
+        for raw_message in self._websocket:  # ← Loops forever until connection closes
+            parsed, is_binary = self._process_message(raw_message)
+            self._emit(EventType.MESSAGE, parsed)
+    finally:
+        self._emit(EventType.CLOSE, None)
+```
+
+When you write:
+```python
+connection.start_listening()
+print("I've started listening!")  # ← THIS NEVER EXECUTES
+```
+
+The print statement never runs because `start_listening()` doesn't return - it's designed to run until the connection closes.
+
+## 📚 Documentation Issues
+
+### Misleading Examples
+
+The documentation shows examples that **cannot work as written**:
+
+**❌ websockets-reference.md (line 52):**
+```python
+connection.start_listening()
+connection.send_media(audio_bytes)  # Never executes!
+```
+
+**❌ README.md (line 62):**
+```python
+connection.start_listening()
+# Any code here never runs!
+```
+
+### Correct Usage (From Working Examples)
+
+**✅ Synchronous (requires threading):**
+```python
+import threading
+
+threading.Thread(target=connection.start_listening, daemon=True).start()
+# Now code continues executing
+connection.send_media(audio_bytes)
+```
+
+**✅ Async (requires task):**
+```python
+import asyncio
+
+listen_task = asyncio.create_task(connection.start_listening())
+# Now code continues executing
+await connection.send_media(audio_bytes)
+```
+
+## 🔧 Why Tests Pass
+
+Tests work because they use **mock websockets** that return a finite set of messages and then stop. In production, real websockets keep connections open indefinitely.
+
+## ✅ Solutions
+
+### Quick Fix for Your Code
+
+**If using sync:**
+```python
+import threading
+
+# Start listening in background
+threading.Thread(target=connection.start_listening, daemon=True).start()
+
+# Now this will print!
+print("I've started listening!")
+```
+
+**If using async:**
+```python
+import asyncio
+
+# Start listening as a task
+listen_task = asyncio.create_task(connection.start_listening())
+
+# Now this will print!
+print("I've started listening!")
+```
+
+### Recommended SDK Fixes
+
+1. **Update documentation** in `websockets-reference.md` and `README.md` to show correct threading/task usage
+2. **Add helper methods** like `start_listening_background()` that handle threading automatically
+3. **Rename method** to `listen_until_closed()` to make blocking behavior explicit
+
+## 📁 Affected Files
+
+- `src/deepgram/listen/v1/socket_client.py`
+- `src/deepgram/listen/v2/socket_client.py`
+- `src/deepgram/speak/v1/socket_client.py`
+- `src/deepgram/agent/v1/socket_client.py`
+- `websockets-reference.md`
+- `README.md`
+
+## 🎯 Next Steps
+
+1. ✅ Bug identified and documented
+2. ⏭️ Fix documentation to show correct usage
+3. ⏭️ Consider adding non-blocking helper methods
+4. ⏭️ Add clear warnings in method docstrings about blocking behavior

--- a/BUG_REPORT.md
+++ b/BUG_REPORT.md
@@ -1,0 +1,158 @@
+# Bug Report: `connection.start_listening()` Blocks Indefinitely
+
+## Summary
+
+The `start_listening()` method in all socket clients **blocks indefinitely** and never returns until the websocket connection is closed. This prevents any code after the call from executing, which is not clearly documented and contradicts the examples shown in the documentation.
+
+## Root Cause
+
+The `start_listening()` method contains a blocking loop that iterates over websocket messages:
+
+### Synchronous Version (e.g., `src/deepgram/listen/v1/socket_client.py:159-180`)
+
+```python
+def start_listening(self):
+    self._emit(EventType.OPEN, None)
+    try:
+        for raw_message in self._websocket:  # ⚠️ BLOCKS HERE - never returns
+            parsed, is_binary = self._process_message(raw_message)
+            self._emit(EventType.MESSAGE, parsed)
+    except (websockets.WebSocketException, JSONDecodeError) as exc:
+        if not isinstance(exc, websockets.exceptions.ConnectionClosedOK):
+            self._emit(EventType.ERROR, exc)
+    finally:
+        self._emit(EventType.CLOSE, None)
+```
+
+### Async Version (e.g., `src/deepgram/listen/v1/socket_client.py:69-90`)
+
+```python
+async def start_listening(self):
+    await self._emit_async(EventType.OPEN, None)
+    try:
+        async for raw_message in self._websocket:  # ⚠️ BLOCKS HERE - never returns
+            parsed, is_binary = self._process_message(raw_message)
+            await self._emit_async(EventType.MESSAGE, parsed)
+    except (websockets.WebSocketException, JSONDecodeError) as exc:
+        if not isinstance(exc, websockets.exceptions.ConnectionClosedOK):
+            await self._emit_async(EventType.ERROR, exc)
+    finally:
+        await self._emit_async(EventType.CLOSE, None)
+```
+
+## Affected Files
+
+- `src/deepgram/listen/v1/socket_client.py` (lines 69-90, 159-180)
+- `src/deepgram/listen/v2/socket_client.py` (lines 67-88, 157-178)
+- `src/deepgram/speak/v1/socket_client.py` (lines 70-91, 161-182)
+- `src/deepgram/agent/v1/socket_client.py` (lines 103-124, 218-239)
+
+## Documentation Inconsistencies
+
+### ❌ Incorrect Examples (Code That Will Never Work)
+
+**websockets-reference.md:52**
+```python
+connection.start_listening()  # This blocks forever!
+
+# This code below will NEVER execute:
+connection.send_media(ListenV1MediaMessage(audio_bytes))
+connection.send_control(ListenV1ControlMessage(type="KeepAlive"))
+```
+
+**README.md:62**
+```python
+connection.start_listening()  # This blocks forever!
+# Any code here will never run
+```
+
+### ✅ Correct Usage (What Actually Works)
+
+**Synchronous (examples/listen/v1/connect/main.py:28)**
+```python
+# Must use threading to avoid blocking
+threading.Thread(target=connection.start_listening, daemon=True).start()
+# Now subsequent code can execute
+```
+
+**Async (examples/listen/v1/connect/async.py:28)**
+```python
+# Must use asyncio.create_task() to avoid blocking
+listen_task = asyncio.create_task(connection.start_listening())
+# Now subsequent code can execute
+```
+
+## User Impact
+
+When users follow the documentation examples in `websockets-reference.md` or `README.md`, they write code like:
+
+```python
+connection.start_listening()
+print("I've started listening!")  # ❌ NEVER PRINTS
+```
+
+The message is never printed because `start_listening()` blocks forever in the loop.
+
+## Recommendations
+
+### Option 1: Fix Documentation (Quick Fix)
+
+Update `websockets-reference.md` and `README.md` to show the correct usage:
+
+**For Sync:**
+```python
+import threading
+
+# Start listening in background thread
+threading.Thread(target=connection.start_listening, daemon=True).start()
+
+# Now you can send messages
+connection.send_media(audio_bytes)
+```
+
+**For Async:**
+```python
+import asyncio
+
+# Start listening as a task
+listen_task = asyncio.create_task(connection.start_listening())
+
+# Now you can send messages
+await connection.send_media(audio_bytes)
+```
+
+### Option 2: Add Non-Blocking Alternative (Better UX)
+
+Create a new method that doesn't block:
+
+```python
+def start_listening_background(self):
+    """Start listening in a background thread (non-blocking)."""
+    import threading
+    threading.Thread(target=self.start_listening, daemon=True).start()
+
+async def start_listening_task(self):
+    """Start listening as an asyncio task (non-blocking)."""
+    import asyncio
+    return asyncio.create_task(self.start_listening())
+```
+
+### Option 3: Rename Current Method (Most Clear)
+
+Rename `start_listening()` to `listen_until_closed()` to make the blocking behavior explicit, and add a non-blocking `start_listening()` wrapper.
+
+## Related Files
+
+All sync examples correctly use threading:
+- `examples/listen/v1/connect/main.py:28`
+- `examples/listen/v2/connect/main.py:28`
+- `examples/speak/v1/connect/main.py:32`
+- `examples/agent/v1/connect/main.py:79`
+
+All async examples correctly use tasks:
+- `examples/listen/v1/connect/async.py:28`
+- `examples/listen/v2/connect/async.py:28`
+- `examples/speak/v1/connect/async.py:31`
+- `examples/agent/v1/connect/async.py:77`
+
+But the documentation doesn't reflect this requirement!


### PR DESCRIPTION
Add bug reports for the `connection.start_listening()` method's blocking behavior and misleading documentation.

The `start_listening()` method blocks indefinitely, preventing subsequent code from executing, which is not clear from its name or the current documentation examples. These reports clarify the expected blocking behavior, provide correct usage patterns (threading/async tasks), and suggest documentation updates or API changes to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-18dd782c-0431-438f-afbc-6e6885e9f040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18dd782c-0431-438f-afbc-6e6885e9f040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive analysis and bug report documenting the blocking behavior of the `start_listening()` method.
  * Documented correct usage patterns using threading and asyncio approaches to prevent blocking.
  * Clarified discrepancies between documented examples and actual implementation behavior across multiple socket client versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->