### PR TITLE
fix: resolves issues with String|String [] encoding

### DIFF
--- a/src/deepgram/listen/v1/client.py
+++ b/src/deepgram/listen/v1/client.py
@@ -53,8 +53,8 @@ class V1Client:
         endpointing: typing.Optional[str] = None,
         extra: typing.Optional[str] = None,
         interim_results: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
-        keywords: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
+        keywords: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         language: typing.Optional[str] = None,
         mip_opt_out: typing.Optional[str] = None,
         model: str,
@@ -63,9 +63,9 @@ class V1Client:
         profanity_filter: typing.Optional[str] = None,
         punctuate: typing.Optional[str] = None,
         redact: typing.Optional[str] = None,
-        replace: typing.Optional[str] = None,
+        replace: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         sample_rate: typing.Optional[str] = None,
-        search: typing.Optional[str] = None,
+        search: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         smart_format: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         utterance_end_ms: typing.Optional[str] = None,
@@ -167,9 +167,17 @@ class V1Client:
         if interim_results is not None:
             query_params = query_params.add("interim_results", interim_results)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if keywords is not None:
-            query_params = query_params.add("keywords", keywords)
+            if isinstance(keywords, str):
+                query_params = query_params.add("keywords", keywords)
+            else:
+                for keyword in keywords:
+                    query_params = query_params.add("keywords", keyword)
         if language is not None:
             query_params = query_params.add("language", language)
         if mip_opt_out is not None:
@@ -187,11 +195,19 @@ class V1Client:
         if redact is not None:
             query_params = query_params.add("redact", redact)
         if replace is not None:
-            query_params = query_params.add("replace", replace)
+            if isinstance(replace, str):
+                query_params = query_params.add("replace", replace)
+            else:
+                for replacement in replace:
+                    query_params = query_params.add("replace", replacement)
         if sample_rate is not None:
             query_params = query_params.add("sample_rate", sample_rate)
         if search is not None:
-            query_params = query_params.add("search", search)
+            if isinstance(search, str):
+                query_params = query_params.add("search", search)
+            else:
+                for term in search:
+                    query_params = query_params.add("search", term)
         if smart_format is not None:
             query_params = query_params.add("smart_format", smart_format)
         if tag is not None:
@@ -264,8 +280,8 @@ class AsyncV1Client:
         endpointing: typing.Optional[str] = None,
         extra: typing.Optional[str] = None,
         interim_results: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
-        keywords: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
+        keywords: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         language: typing.Optional[str] = None,
         mip_opt_out: typing.Optional[str] = None,
         model: str,
@@ -274,9 +290,9 @@ class AsyncV1Client:
         profanity_filter: typing.Optional[str] = None,
         punctuate: typing.Optional[str] = None,
         redact: typing.Optional[str] = None,
-        replace: typing.Optional[str] = None,
+        replace: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         sample_rate: typing.Optional[str] = None,
-        search: typing.Optional[str] = None,
+        search: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         smart_format: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         utterance_end_ms: typing.Optional[str] = None,
@@ -378,9 +394,17 @@ class AsyncV1Client:
         if interim_results is not None:
             query_params = query_params.add("interim_results", interim_results)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if keywords is not None:
-            query_params = query_params.add("keywords", keywords)
+            if isinstance(keywords, str):
+                query_params = query_params.add("keywords", keywords)
+            else:
+                for keyword in keywords:
+                    query_params = query_params.add("keywords", keyword)
         if language is not None:
             query_params = query_params.add("language", language)
         if mip_opt_out is not None:
@@ -398,11 +422,19 @@ class AsyncV1Client:
         if redact is not None:
             query_params = query_params.add("redact", redact)
         if replace is not None:
-            query_params = query_params.add("replace", replace)
+            if isinstance(replace, str):
+                query_params = query_params.add("replace", replace)
+            else:
+                for replacement in replace:
+                    query_params = query_params.add("replace", replacement)
         if sample_rate is not None:
             query_params = query_params.add("sample_rate", sample_rate)
         if search is not None:
-            query_params = query_params.add("search", search)
+            if isinstance(search, str):
+                query_params = query_params.add("search", search)
+            else:
+                for term in search:
+                    query_params = query_params.add("search", term)
         if smart_format is not None:
             query_params = query_params.add("smart_format", smart_format)
         if tag is not None:

--- a/src/deepgram/listen/v1/raw_client.py
+++ b/src/deepgram/listen/v1/raw_client.py
@@ -34,8 +34,8 @@ class RawV1Client:
         endpointing: typing.Optional[str] = None,
         extra: typing.Optional[str] = None,
         interim_results: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
-        keywords: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
+        keywords: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         language: typing.Optional[str] = None,
         mip_opt_out: typing.Optional[str] = None,
         model: str,
@@ -44,9 +44,9 @@ class RawV1Client:
         profanity_filter: typing.Optional[str] = None,
         punctuate: typing.Optional[str] = None,
         redact: typing.Optional[str] = None,
-        replace: typing.Optional[str] = None,
+        replace: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         sample_rate: typing.Optional[str] = None,
-        search: typing.Optional[str] = None,
+        search: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         smart_format: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         utterance_end_ms: typing.Optional[str] = None,
@@ -148,9 +148,17 @@ class RawV1Client:
         if interim_results is not None:
             query_params = query_params.add("interim_results", interim_results)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if keywords is not None:
-            query_params = query_params.add("keywords", keywords)
+            if isinstance(keywords, str):
+                query_params = query_params.add("keywords", keywords)
+            else:
+                for keyword in keywords:
+                    query_params = query_params.add("keywords", keyword)
         if language is not None:
             query_params = query_params.add("language", language)
         if mip_opt_out is not None:
@@ -168,11 +176,19 @@ class RawV1Client:
         if redact is not None:
             query_params = query_params.add("redact", redact)
         if replace is not None:
-            query_params = query_params.add("replace", replace)
+            if isinstance(replace, str):
+                query_params = query_params.add("replace", replace)
+            else:
+                for replacement in replace:
+                    query_params = query_params.add("replace", replacement)
         if sample_rate is not None:
             query_params = query_params.add("sample_rate", sample_rate)
         if search is not None:
-            query_params = query_params.add("search", search)
+            if isinstance(search, str):
+                query_params = query_params.add("search", search)
+            else:
+                for term in search:
+                    query_params = query_params.add("search", term)
         if smart_format is not None:
             query_params = query_params.add("smart_format", smart_format)
         if tag is not None:
@@ -224,8 +240,8 @@ class AsyncRawV1Client:
         endpointing: typing.Optional[str] = None,
         extra: typing.Optional[str] = None,
         interim_results: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
-        keywords: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
+        keywords: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         language: typing.Optional[str] = None,
         mip_opt_out: typing.Optional[str] = None,
         model: str,
@@ -234,9 +250,9 @@ class AsyncRawV1Client:
         profanity_filter: typing.Optional[str] = None,
         punctuate: typing.Optional[str] = None,
         redact: typing.Optional[str] = None,
-        replace: typing.Optional[str] = None,
+        replace: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         sample_rate: typing.Optional[str] = None,
-        search: typing.Optional[str] = None,
+        search: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         smart_format: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         utterance_end_ms: typing.Optional[str] = None,
@@ -338,9 +354,17 @@ class AsyncRawV1Client:
         if interim_results is not None:
             query_params = query_params.add("interim_results", interim_results)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if keywords is not None:
-            query_params = query_params.add("keywords", keywords)
+            if isinstance(keywords, str):
+                query_params = query_params.add("keywords", keywords)
+            else:
+                for keyword in keywords:
+                    query_params = query_params.add("keywords", keyword)
         if language is not None:
             query_params = query_params.add("language", language)
         if mip_opt_out is not None:
@@ -358,11 +382,19 @@ class AsyncRawV1Client:
         if redact is not None:
             query_params = query_params.add("redact", redact)
         if replace is not None:
-            query_params = query_params.add("replace", replace)
+            if isinstance(replace, str):
+                query_params = query_params.add("replace", replace)
+            else:
+                for replacement in replace:
+                    query_params = query_params.add("replace", replacement)
         if sample_rate is not None:
             query_params = query_params.add("sample_rate", sample_rate)
         if search is not None:
-            query_params = query_params.add("search", search)
+            if isinstance(search, str):
+                query_params = query_params.add("search", search)
+            else:
+                for term in search:
+                    query_params = query_params.add("search", term)
         if smart_format is not None:
             query_params = query_params.add("smart_format", smart_format)
         if tag is not None:

--- a/src/deepgram/listen/v2/client.py
+++ b/src/deepgram/listen/v2/client.py
@@ -43,7 +43,7 @@ class V2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -100,7 +100,11 @@ class V2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:
@@ -154,7 +158,7 @@ class AsyncV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -211,7 +215,11 @@ class AsyncV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:

--- a/src/deepgram/listen/v2/raw_client.py
+++ b/src/deepgram/listen/v2/raw_client.py
@@ -31,7 +31,7 @@ class RawV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -88,7 +88,11 @@ class RawV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:
@@ -131,7 +135,7 @@ class AsyncRawV2Client:
         eager_eot_threshold: typing.Optional[str] = None,
         eot_threshold: typing.Optional[str] = None,
         eot_timeout_ms: typing.Optional[str] = None,
-        keyterm: typing.Optional[str] = None,
+        keyterm: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None,
         mip_opt_out: typing.Optional[str] = None,
         tag: typing.Optional[str] = None,
         authorization: typing.Optional[str] = None,
@@ -188,7 +192,11 @@ class AsyncRawV2Client:
         if eot_timeout_ms is not None:
             query_params = query_params.add("eot_timeout_ms", eot_timeout_ms)
         if keyterm is not None:
-            query_params = query_params.add("keyterm", keyterm)
+            if isinstance(keyterm, str):
+                query_params = query_params.add("keyterm", keyterm)
+            else:
+                for term in keyterm:
+                    query_params = query_params.add("keyterm", term)
         if mip_opt_out is not None:
             query_params = query_params.add("mip_opt_out", mip_opt_out)
         if tag is not None:


### PR DESCRIPTION
## PR Summary

### Fix: String|String[] parameter URL encoding for WebSocket clients

**Issue:** [#629](https://github.com/deepgram/deepgram-python-sdk/issues/629)

**Problem:**  
When passing list values to `keyterm`, `keywords`, `replace`, and `search` parameters in WebSocket clients, the SDK incorrectly URL-encoded the entire list as a string (e.g., `keyterm=%5B%27TERM1%27%2C+%27TERM2%27%5D`) instead of creating multiple query parameters (e.g., `keyterm=TERM1&keyterm=TERM2`).

**Solution:**  
- Updated type signatures to accept `typing.Union[str, typing.Sequence[str]]`
- Added runtime logic to check parameter type and iterate over sequences
- Each list item now correctly adds a separate query parameter

**Files Changed:**
- `src/deepgram/listen/v1/client.py` - Fixed: keyterm, keywords, replace, search
- `src/deepgram/listen/v1/raw_client.py` - Fixed: keyterm, keywords, replace, search
- `src/deepgram/listen/v2/client.py` - Fixed: keyterm
- `src/deepgram/listen/v2/raw_client.py` - Fixed: keyterm

**Testing:**
- ✅ All 467 unit tests pass
- ✅ Validated with reproduction scripts showing correct URL encoding
- ✅ Backward compatible (single strings still work)

**Note:** REST/media API clients already handled this correctly; only WebSocket clients were affected.



## Reproduction Script used for testing

```python
"""
Simple validation test - captures actual WebSocket URLs and validates encoding
"""
import os
import sys
from unittest.mock import patch, MagicMock
from deepgram import DeepgramClient

# Get API key
api_key = os.getenv("DEEPGRAM_API_KEY", "test_key")
client = DeepgramClient(api_key=api_key)

print("="*80)
print("SDK FIX VALIDATION - URL ENCODING TEST")
print("="*80)

results = {}

def test_parameter(test_name, connect_func, expected_url_pattern):
    """Test a parameter and validate the URL encoding"""
    print(f"\n{test_name}")
    print("-"*80)

    captured_url = None

    # Mock the websocket to capture the URL
    with patch('websockets.sync.client.connect') as mock_connect:
        mock_protocol = MagicMock()
        mock_connect.return_value.__enter__ = lambda self: mock_protocol
        mock_connect.return_value.__exit__ = lambda self, *args: None

        try:
            connect_func()
            # Get the URL that was passed to websocket connect
            captured_url = mock_connect.call_args[0][0] if mock_connect.called else None
        except Exception as e:
            print(f"Error during connection: {e}")

    if not captured_url:
        print(f"❌ FAIL - No URL captured")
        results[test_name] = False
        return

    print(f"Captured URL: {captured_url}")
    print(f"Expected pattern: {expected_url_pattern}")

    # Check if the URL contains the expected pattern
    if expected_url_pattern in captured_url:
        print(f"✅ PASS - URL encoding is correct")
        results[test_name] = True
    else:
        print(f"❌ FAIL - URL encoding is incorrect")
        results[test_name] = False

# TEST 1: v1 keyterm with list
def test1():
    with client.listen.v1.connect(model="nova-3", keyterm=["TERM1", "TERM2"]) as conn:
        pass

test_parameter(
    "TEST 1: v1 keyterm=['TERM1', 'TERM2']",
    test1,
    "keyterm=TERM1&keyterm=TERM2"
)

# TEST 2: v1 keywords with list
def test2():
    with client.listen.v1.connect(model="nova-2", keywords=["word1", "word2"]) as conn:
        pass

test_parameter(
    "TEST 2: v1 keywords=['word1', 'word2']",
    test2,
    "keywords=word1&keywords=word2"
)

# TEST 3: v1 replace with list
def test3():
    with client.listen.v1.connect(model="nova-3", replace=["old1:new1", "old2:new2"]) as conn:
        pass

test_parameter(
    "TEST 3: v1 replace=['old1:new1', 'old2:new2']",
    test3,
    "replace=old1%3Anew1&replace=old2%3Anew2"
)

# TEST 4: v1 search with list
def test4():
    with client.listen.v1.connect(model="nova-3", search=["term1", "term2"]) as conn:
        pass

test_parameter(
    "TEST 4: v1 search=['term1', 'term2']",
    test4,
    "search=term1&search=term2"
)

# TEST 5: v2 keyterm with list
def test5():
    with client.listen.v2.connect(
        model="flux-general-en",
        encoding="linear16",
        sample_rate="16000",
        keyterm=["TERM1", "TERM2"]
    ) as conn:
        pass

test_parameter(
    "TEST 5: v2 keyterm=['TERM1', 'TERM2']",
    test5,
    "keyterm=TERM1&keyterm=TERM2"
)

# SUMMARY
print("\n" + "="*80)
print("RESULTS")
print("="*80)

all_passed = all(results.values())
for test_name, passed in results.items():
    status = "✅ PASS" if passed else "❌ FAIL"
    print(f"{status} - {test_name}")

print("="*80)
if all_passed:
    print("🎉 ALL TESTS PASSED")
    sys.exit(0)
else:
    print("❌ SOME TESTS FAILED")
    sys.exit(1)





```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search and listen parameters: keyterm, keywords, replace, and search now accept multiple values in addition to single values, enabling more powerful and flexible query configurations across all API versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211917378264536