### PR TITLE
fix(types): change speaker and related fields from float to int

### DIFF
--- a/src/deepgram/types/listen_v1response_results_channels_item_alternatives_item_paragraphs_paragraphs_item.py
+++ b/src/deepgram/types/listen_v1response_results_channels_item_alternatives_item_paragraphs_paragraphs_item.py
@@ -13,8 +13,8 @@ class ListenV1ResponseResultsChannelsItemAlternativesItemParagraphsParagraphsIte
     sentences: typing.Optional[
         typing.List[ListenV1ResponseResultsChannelsItemAlternativesItemParagraphsParagraphsItemSentencesItem]
     ] = None
-    speaker: typing.Optional[float] = None
-    num_words: typing.Optional[float] = None
+    speaker: typing.Optional[int] = None
+    num_words: typing.Optional[int] = None
     start: typing.Optional[float] = None
     end: typing.Optional[float] = None
 

--- a/src/deepgram/types/listen_v1response_results_utterances_item.py
+++ b/src/deepgram/types/listen_v1response_results_utterances_item.py
@@ -11,10 +11,10 @@ class ListenV1ResponseResultsUtterancesItem(UniversalBaseModel):
     start: typing.Optional[float] = None
     end: typing.Optional[float] = None
     confidence: typing.Optional[float] = None
-    channel: typing.Optional[float] = None
+    channel: typing.Optional[int] = None
     transcript: typing.Optional[str] = None
     words: typing.Optional[typing.List[ListenV1ResponseResultsUtterancesItemWordsItem]] = None
-    speaker: typing.Optional[float] = None
+    speaker: typing.Optional[int] = None
     id: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/src/deepgram/types/listen_v1response_results_utterances_item_words_item.py
+++ b/src/deepgram/types/listen_v1response_results_utterances_item_words_item.py
@@ -11,7 +11,7 @@ class ListenV1ResponseResultsUtterancesItemWordsItem(UniversalBaseModel):
     start: typing.Optional[float] = None
     end: typing.Optional[float] = None
     confidence: typing.Optional[float] = None
-    speaker: typing.Optional[float] = None
+    speaker: typing.Optional[int] = None
     speaker_confidence: typing.Optional[float] = None
     punctuated_word: typing.Optional[str] = None
 


### PR DESCRIPTION
## Summary
Fixes #641 

Changed speaker, channel, and num_words fields from `float` to `int` in Listen V1 response types to match the actual API response format.

## Issue
In SDK v5, the speaker field was incorrectly defined as `float`, causing subtitle generation tools like `deepgram-captions` to display speakers as "speaker 0.0", "speaker 1.0" instead of "speaker 0", "speaker 1". This is a regression from SDK v4.8.

## Changes
Modified the following type definition files:
1. `listen_v1response_results_utterances_item.py` - Changed `speaker` and `channel` from `float` to `int`
2. `listen_v1response_results_utterances_item_words_item.py` - Changed `speaker` from `float` to `int`
3. `listen_v1response_results_channels_item_alternatives_item_paragraphs_paragraphs_item.py` - Changed `speaker` and `num_words` from `float` to `int`

## Test plan
- Verify that speaker IDs are now returned as integers (0, 1, 2) instead of floats (0.0, 1.0, 2.0)
- Test with deepgram-captions package to ensure subtitles display "speaker 0" format
- Ensure backward compatibility with existing code