### PR TITLE
chore: add context7 mcp server configuration [no-ci]

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/deepgram/deepgram-python-sdk",
+  "public_key": "pk_hu7APZeIXQ14hNyaCBm0A"
+}


### PR DESCRIPTION
Adds Context7 MCP server configuration to enable documentation lookups for the Python SDK.\n\nThis is a non-release change (marked [no-ci] to prevent release-please from triggering).