### PR TITLE
fix: widen pydantic-core upper bound to <3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ aiohttp = { version = ">=3.13.4,<4", optional = true, python = ">=3.9"}
 httpx = ">=0.21.2"
 httpx-aiohttp = { version = "0.1.8", optional = true, python = ">=3.9"}
 pydantic = ">= 1.9.2"
-pydantic-core = ">=2.18.2,<2.44.0"
+pydantic-core = ">=2.18.2,<3.0.0"
 typing_extensions = ">= 4.0.0"
 websockets = ">=12.0"
 


### PR DESCRIPTION
## Problem

`deepgram-sdk` pins `pydantic-core>=2.18.2,<2.44.0`, but `pydantic>=2.13.0` requires `pydantic-core==2.46.3`. This makes it impossible to install `deepgram-sdk` alongside modern `pydantic`:

```
Because pydantic==2.13.3 depends on pydantic-core==2.46.3 and deepgram-sdk==7.0.0
depends on pydantic-core>=2.18.2,<2.44.0, we can conclude that deepgram-sdk==7.0.0 and
pydantic==2.13.3 are incompatible.
```

Fixes #701

## Fix

Widen the `pydantic-core` upper bound from `<2.44.0` to `<3.0.0`. 

`pydantic-core` follows calver and the validation/serialization API is stable within major versions. The lower bound `>=2.18.2` is preserved to maintain backward compatibility.

## Testing

Verified that `pydantic==2.13.3` + `pydantic-core==2.46.3` satisfies the new constraint `>=2.18.2,<3.0.0`.